### PR TITLE
Remove type check on zcrawpour which is not necessary and causes errors with the RPC.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2447,8 +2447,6 @@ Value zc_raw_pour(const json_spirit::Array& params, bool fHelp)
             );
     }
 
-    RPCTypeCheck(params, boost::assign::list_of(str_type)(obj_type)(obj_type)(int_type)(int_type));
-
     LOCK(cs_main);
 
     CTransaction tx;


### PR DESCRIPTION
We want to accept an int and a real in the same parameter for zcrawpour, but this isn't possible. Other RPC routines skip this type check -- it has no implications for memory safety, it's just for informative error messages. In our case they should be informative enough anyway.