### PR TITLE
Ignore certificate errors when fetching params.

### DIFF
--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -21,7 +21,14 @@ function fetch_params {
     if ! [ -f "$filename" ]
     then
         echo "Retrieving: $url"
-        wget --progress=dot:giga "$url"
+        # Note: --no-check-certificate should be ok, since we rely on
+        # sha256 for integrity, and there's no confidentiality requirement.
+        # Our website uses letsencrypt certificates which are not supported
+        # by some wget installations, so we expect some cert failures.
+        wget \
+            --progress=dot:giga \
+            --no-check-certificate \
+            "$url"
     fi
 }
 


### PR DESCRIPTION
We already have sha256 integrity, no need for confidentiality/DNS authentication.

Fixes #641.